### PR TITLE
Create lint workflow which uses Prettier, HTMLHint, and Stylelint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+# Lints all merges into main branch
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run-all-lints:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Prettier
+        run: npm install --save-dev --save-exact prettier
+      - name: Run Prettier on all files
+        run: npx prettier --config ./.prettierrc --write .
+
+      - name: Install HTMLHint
+        run: npm install --save-dev htmlhint
+      - name: Run HTMLHint on all HTML files
+        run: npx htmlhint --config ./.htmlhintrc "**/*.html"
+
+      - name: Install Stylelint
+        run: npm install --save-dev stylelint stylelint-config-standard
+      - name: Run Stylelint on all CSS files
+        run: npx stylelint --config ./.stylelintrc --allow-empty-input "**/*.css"

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,12 @@
+{
+  "attr-lowercase": true,
+  "attr-no-duplication": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": true,
+  "id-unique": true,
+  "spec-char-escape": true,
+  "src-not-empty": true,
+  "tag-pair": true,
+  "tagname-lowercase": true,
+  "title-require": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}


### PR DESCRIPTION
Resolves #36

**Description**

Sets up a lint workflow that runs Prettier, HTMLHint, and Stylelint on all pull requests into `main`.

The `.prettierrc`, `.htmlhintrc`, and `.stylelintrc` files are config files that set the configuration options for Prettier, HTMLHint, and Stylelint, respectively. The config files for HTMLHint and Stylelint use the default recommended options for each lint. The config file for Prettier has been slightly modified. The modified options in the Prettier config file and be found [here](https://prettier.io/docs/en/options.html).

In the actual workflow file `lint.yml`, the workflow runs a job called `run-all-lints` which runs on a virtual Ubuntu server. This job will then install and use the latest version of Node.js. Node.js is used to install and run the lints for Prettier, HTMLHint, and Stylelint.

Note: you can see how this workflow runs on PRs by looking at the `All checks have passed` section below or by clicking the `Checks` tab above.