### PR TITLE
Set ECMAScript version to 9 to remove unnecessary warnings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "bitwise": false,
   "curly": true,
   "eqeqeq": true,
+  "esversion": 9,
   "forin": true,
   "futurehostile": false,
   "latedef": true,


### PR DESCRIPTION
**Description**

Adds one extra setting to the JSHint config to remove the annoying ECMAScript version warnings
