### PR TITLE
Added functionality to Select Cookbook popup

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -234,16 +234,14 @@
           <p>Select Cookbook</p>
           <div class="dropdown">
             <select name="cookbooks" id="cookbooks">
-              <option value="none">Cookbook Name</option>
+              <option value="" selected="true" disabled="true">
+                - Select a Cookbook -
+              </option>
               <option value="cookbook1">Cookbook 1</option>
-              <option value="cookbook2">Cookbook 2</option>
-              <option value="cookbook3">Cookbook 3</option>
-              <option value="cookbook4">Cookbook 4</option>
-              <option value="cookbook5">Cookbook 5</option>
             </select>
           </div>
         </div>
-        <button class="secondary-button">Add</button>
+        <button class="secondary-button" id="add-button">Add</button>
       </div>
     </template>
 

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -221,7 +221,7 @@ async function populateExplorePage(/* TODO: filtersObj */) {
     shadow.getElementById("no-results-text").classList.add("make-invisible");
     let recipeCards = shadow.getElementById("recipe-cards-section").children;
 
-    for (let i = 0; i < recipes.length; ++i) {
+    for (let i = 0; i < EXPLORE_PAGE_NUM_RESULTS; ++i) {
       recipeCards[i].classList.remove("make-invisible");
       let shadow = recipeCards[i].shadowRoot;
       shadow.getElementById("recipe-id").textContent = recipes[i].id;
@@ -312,7 +312,7 @@ async function populateHomePage() {
   let recipes = await spoonacular.getRandomRecipes(HOME_PAGE_NUM_RESULTS);
   let recipeCards = explore.children;
 
-  for (let i = 0; i < recipes.length; ++i) {
+  for (let i = 0; i < HOME_PAGE_NUM_RESULTS; ++i) {
     let shadow = recipeCards[i].shadowRoot;
     shadow.getElementById("recipe-id").textContent = recipes[i].id;
     shadow.getElementById("recipe-card-title").textContent = recipes[i].title;

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -469,6 +469,12 @@ async function populateSelectCookbookOptions() {
   }
 }
 
+/**
+ * In the Select Cookbooks popup, this function binds the X button to close
+ * the popup and binds the Add button to save the currently opened recipe to
+ * the selected cookbook
+ * @function bindSelectCookbookButtons
+ */
 function bindSelectCookbookButtons() {
   "use strict";
   let notificationSelectCookbook = document.querySelector(

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -487,10 +487,8 @@ function bindSelectCookbookButtons() {
   addButton.addEventListener("click", async () => {
     let recipePage = document.querySelector("recipe-page");
     let selectedCookbook = shadow.getElementById("cookbooks").value;
-    console.log("click");
 
     if (selectedCookbook !== "" && !recipePage.classList.contains("hidden")) {
-      console.log("saved");
       let recipeId =
         recipePage.shadowRoot.getElementById("recipe-page-id").textContent;
       let recipeObj = await spoonacular.getRecipeInfo(recipeId);

--- a/source/styles/notification-select-cookbook.css
+++ b/source/styles/notification-select-cookbook.css
@@ -1,16 +1,21 @@
 .notification {
-  position: absolute;
+  position: fixed;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   overflow: hidden;
   text-align: left;
   padding: 10px;
+  border-style: solid;
+  border-width: 0.5vw;
   border-radius: 5px;
+  border-color: #ba181b;
   box-shadow: 0 5px 10px rgba(0 0 0 / 20%);
   width: 300px;
   z-index: 999;
   font-weight: bold;
   font-family: Helvetica, sans-serif;
+  background-color: #fff;
 
   /* Used for the popup
   opacity: 0%;


### PR DESCRIPTION
Resolves #135

**Description**

Adds functionality to the Select Cookbook popup. The `X` button will hide the popup. The `Add` button will not do anything unless a cookbook is first selected. When a cookbook is selected, data about the currently opened recipe will be fetched and stored in the selected cookbook. Then the popup will close.

Here is a video showing the functionality:

https://user-images.githubusercontent.com/31702110/142347916-d3213cdf-9b4b-439d-99df-7788da5ec092.mp4