### PR TITLE
Cookbook cards

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "esversion": 9,
   "forin": true,
   "futurehostile": false,
-  "latedef": true,
+  "latedef": "nofunc",
   "leanswitch": true,
   "nonbsp": true,
   "nonew": true,

--- a/source/components/cookbook-card.js
+++ b/source/components/cookbook-card.js
@@ -5,17 +5,41 @@ class cookbookCard extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+  }
+
+  /**
+   * Sets the cookbook for the given card and populates the text within it
+   */
+  set cookbook(cookbookObj) {
+    if (!cookbookObj) {
+      return;
+    }
 
     const stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
     stylesheet.href = "/source/styles/cookbook-card.css";
 
-    const navbar = document
+    const card = document
       .getElementById("cookbook-card-template")
-      .cloneNode(true);
+      .content.cloneNode(true);
 
+    // store object within card for easy access
+    this.cookbookObj = cookbookObj;
+
+    // add cookbook info
+    let titleText = card.querySelector(".title");
+    titleText.textContent = cookbookObj.title;
+
+    let descriptionText = card.querySelector(".detailed-description");
+    descriptionText.textContent = cookbookObj.description;
+
+    // add to element
     this.shadowRoot.append(stylesheet);
-    this.shadowRoot.append(navbar);
+    this.shadowRoot.append(card);
+  }
+
+  get cookbook() {
+    return this.cookbookObj;
   }
 }
 

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -575,9 +575,41 @@ async function populateCookbooksPage() {
   for (const cookbook of cookbooks) {
     let card = document.createElement("cookbook-card");
     card.cookbook = cookbook;
+    bindCookbookCardButtons(card);
 
     cardContainer.appendChild(card);
   }
+}
+
+/**
+ * Attaches event listeners to the buttons within a given cookbook card
+ * @function bindCookbookCardButtons
+ * @param {object} card The cookbook card element
+ */
+function bindCookbookCardButtons(card) {
+  "use strict";
+
+  // get references to the buttons in the card
+  let shadow = card.shadowRoot;
+  let editButton = shadow.getElementById("edit");
+  let removeButton = shadow.getElementById("remove");
+  let openButton = shadow.getElementById("open");
+
+  editButton.addEventListener("click", () => {
+    // TODO set up cookbook editing
+    router.navigate("create-cookbook");
+  });
+
+  removeButton.addEventListener("click", async () => {
+    // delete cookbook, then repopulate page
+    await indexedDb.deleteCookbook(card.cookbook.title);
+    populateCookbooksPage();
+  });
+
+  openButton.addEventListener("click", () => {
+    // TODO set up cookbook page
+    router.navigate("single-cookbook");
+  });
 }
 
 // TODO trigger this function when cookbooks are added, edited, or deleted

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -758,7 +758,6 @@ async function init() {
   };
   populateRecipePage(recipeObj, true);
 
-  // indexedDb.createCookbook("Example Title", "This is an example description!");
   populateCookbooksPage();
   // TODO
 }

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -554,6 +554,32 @@ function populateRecipePage(recipeObj, fromSpoonacular) {
   }
 }
 
+/**
+ * Populate the my cookbooks page with cookbook cards
+ * @function populateCookbooksPage
+ */
+async function populateCookbooksPage() {
+  "use strict";
+
+  // get reference to cookbook page and the card section
+  let shadow = document.querySelector("cook-book").shadowRoot;
+  let cardContainer = shadow.getElementById("cards");
+
+  // clear any existing cards
+  cardContainer.innerHTML = "";
+
+  // get cookbooks from db
+  let cookbooks = await indexedDb.getAllCookbooks();
+
+  // add each cookbook to the page as a new card
+  for (const cookbook of cookbooks) {
+    let card = document.createElement("cookbook-card");
+    card.cookbook = cookbook;
+
+    cardContainer.appendChild(card);
+  }
+}
+
 // TODO trigger this function when cookbooks are added, edited, or deleted
 /**
  * Populates the Select Cookbook notification options with all of the user's
@@ -699,6 +725,9 @@ async function init() {
     instructions: ["instruction-1", "instruction-2"],
   };
   populateRecipePage(recipeObj, true);
+
+  // indexedDb.createCookbook("Example Title", "This is an example description!");
+  populateCookbooksPage();
   // TODO
 }
 


### PR DESCRIPTION
Resolves #116, #118, #119, #120

**Description**

Sets up cookbook cards to be easily created, populates the "My Cookbooks" page with them, and binds their action buttons. I used a setter for the cookbook card data, which I think should be the standard moving forward to reduce redundancy (should be mirrored in recipe cards, potentially a sprint 2 issue).

I had to change the JSHint `latedef` option to `nofunc`, since otherwise I could not create the event listener with a reference back to `populateCookbooksPage`.
