### PR TITLE
Single cookbook view recipe cards

### DIFF
--- a/source/components/recipe-card-delete.js
+++ b/source/components/recipe-card-delete.js
@@ -6,6 +6,15 @@ class RecipeCardDelete extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+  }
+
+  /**
+   * Sets the recipe object for a given card and sets up content
+   */
+  set recipe(recipeObj) {
+    if (!recipeObj) {
+      return;
+    }
 
     const stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
@@ -13,11 +22,30 @@ class RecipeCardDelete extends HTMLElement {
 
     const recipeCard = document
       .getElementById("recipe-card-delete-template")
-      .cloneNode(true);
+      .content.cloneNode(true);
 
+    // store object for access later
+    this.recipeObj = recipeObj;
+
+    // set up card content
+    let titleText = recipeCard.querySelector("h1");
+    titleText.textContent = recipeObj.title;
+
+    let descriptionText = recipeCard.querySelector(".description");
+    descriptionText.textContent = recipeObj.description;
+
+    let image = recipeCard.querySelector("img");
+    image.src = recipeObj.image;
+
+    // add to element
     this.shadowRoot.append(stylesheet);
     this.shadowRoot.append(recipeCard);
   }
+
+  get recipe() {
+    return this.recipeObj;
+  }
+
 }
 
 customElements.define("recipe-card-delete", RecipeCardDelete);

--- a/source/components/recipe-card-delete.js
+++ b/source/components/recipe-card-delete.js
@@ -45,7 +45,6 @@ class RecipeCardDelete extends HTMLElement {
   get recipe() {
     return this.recipeObj;
   }
-
 }
 
 customElements.define("recipe-card-delete", RecipeCardDelete);

--- a/source/components/recipe-card-delete.js
+++ b/source/components/recipe-card-delete.js
@@ -32,7 +32,7 @@ class RecipeCardDelete extends HTMLElement {
     titleText.textContent = recipeObj.title;
 
     let descriptionText = recipeCard.querySelector(".description");
-    descriptionText.textContent = recipeObj.description;
+    descriptionText.innerHTML = recipeObj.description;
 
     let image = recipeCard.querySelector("img");
     image.src = recipeObj.image;

--- a/source/index.html
+++ b/source/index.html
@@ -423,12 +423,7 @@
         <section class="recipes">
           <h2 class="recipe-header">My Recipes</h2>
           <div class="recipe-container">
-            <!-- test for adding recipe -->
             <!-- add recipe cards -->
-            <div class="recipe-cards"></div>
-            <div class="recipe-cards"></div>
-            <div class="recipe-cards"></div>
-            <div class="recipe-cards"></div>
           </div>
         </section>
         <!-- add button -->

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -606,6 +606,12 @@ function bindCookbookCardButtons(card) {
   });
 }
 
+/**
+ * Populates the single cookbook view with the recipe cards of the 
+ * given cookbook.
+ * @function populateSingleCookbook
+ * @param {object} cookbook The cookbook object from indexedDb
+ */
 async function populateSingleCookbook(cookbook) {
   "use strict";
 
@@ -634,6 +640,15 @@ async function populateSingleCookbook(cookbook) {
   }
 }
 
+// TODO avoid using so many params
+/**
+ * Attaches event listeners to the buttons within a recipe card in the single cookbook view
+ * @function bindCookbookRecipeCardButtons
+ * @param {object} card The recipe card element
+ * @param {object} recipe The recipe object
+ * @param {object} recipeKey The key of the recipe object within the cookbook
+ * @param {object} cookbook The cookbook object
+ */
 function bindCookbookRecipeCardButtons(card, recipe, recipeKey, cookbook) {
   "use strict";
 

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -607,7 +607,7 @@ function bindCookbookCardButtons(card) {
 }
 
 /**
- * Populates the single cookbook view with the recipe cards of the 
+ * Populates the single cookbook view with the recipe cards of the
  * given cookbook.
  * @function populateSingleCookbook
  * @param {object} cookbook The cookbook object from indexedDb

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -839,7 +839,7 @@ async function init() {
 
   populateSelectCookbookOptions();
   bindSelectCookbookButtons();
- 
+
   populateCookbooksPage();
 }
 

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -607,8 +607,56 @@ function bindCookbookCardButtons(card) {
   });
 
   openButton.addEventListener("click", () => {
-    // TODO set up cookbook page
     router.navigate("single-cookbook");
+    populateSingleCookbook(card.cookbook);
+  });
+}
+
+async function populateSingleCookbook(cookbook) {
+  "use strict";
+
+  // get reference to single cookbook page & elements
+  let shadow = document.querySelector("single-cookbook").shadowRoot;
+  let title = shadow.querySelector(".title");
+  let cardContainer = shadow.querySelector(".recipe-container");
+
+  title.textContent = cookbook.title;
+
+  // clear all cards that were previously added
+  cardContainer.innerHTML = "";
+
+  let recipes = await indexedDb.getAllRecipes(cookbook.title);
+  for (const key in recipes) {
+    if (recipes.hasOwnProperty(key)) {
+      // TODO consolidate with regular recipe card
+      // set up card
+      const recipe = recipes[key];
+      let card = document.createElement("recipe-card-delete");
+      card.recipe = recipe;
+      bindCookbookRecipeCardButtons(card, recipe, key, cookbook);
+
+      cardContainer.appendChild(card);
+    }
+  }
+}
+
+function bindCookbookRecipeCardButtons(card, recipe, recipeKey, cookbook) {
+  "use strict";
+
+  // get button references
+  let shadow = card.shadowRoot;
+  let openButton = shadow.querySelector(".recipe-action-button");
+  let deleteButton = shadow.querySelector(".recipe-delete-button");
+
+  openButton.addEventListener("click", () => {
+    router.navigate("recipe-page");
+    populateRecipePage(recipe, false);
+  });
+
+  deleteButton.addEventListener("click", async () => {
+    // delete, then repopulate to clear it
+    await indexedDb.deleteRecipe(cookbook.title, recipeKey);
+    populateSingleCookbook(cookbook);
   });
 }
 
@@ -758,7 +806,6 @@ async function init() {
   };
   populateRecipePage(recipeObj, true);
 
-  // indexedDb.createCookbook("Example Title", "This is an example description!");
   populateCookbooksPage();
   // TODO
 }

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -600,9 +600,9 @@ function bindCookbookCardButtons(card) {
     populateCookbooksPage();
   });
 
-  openButton.addEventListener("click", () => {
+  openButton.addEventListener("click", async () => {
+    await populateSingleCookbook(card.cookbook);
     router.navigate("single-cookbook");
-    populateSingleCookbook(card.cookbook);
   });
 }
 
@@ -658,8 +658,8 @@ function bindCookbookRecipeCardButtons(card, recipe, recipeKey, cookbook) {
   let deleteButton = shadow.querySelector(".recipe-delete-button");
 
   openButton.addEventListener("click", () => {
-    router.navigate("recipe-page");
     populateRecipePage(recipe, false);
+    router.navigate("recipe-page");
   });
 
   deleteButton.addEventListener("click", async () => {


### PR DESCRIPTION
Resolves #121  #122 #124 

**Description**

Populates the single cookbook page with the recipe cards of the cookbook's saved recipes. Binds the cards' learn more and delete buttons.

I set up a getter/setter for recipe data on the cards, but in sprint 2 the `recipe-card-delete` element should be folded into the regular `recipe-card` element to remove redundancy. The CSS for `recipe-card-delete` also appears to be broken.