### PR TITLE
Default cookbook

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -307,9 +307,7 @@
           <p>Select Cookbook</p>
           <div class="dropdown">
             <select name="cookbooks" id="cookbooks">
-              <option value="My cookbook" selected="true">
-                My cookbook
-              </option>
+              <option value="My cookbook" selected="true">My cookbook</option>
               <option value="cookbook1">Cookbook 1</option>
             </select>
           </div>

--- a/source/index.html
+++ b/source/index.html
@@ -307,8 +307,8 @@
           <p>Select Cookbook</p>
           <div class="dropdown">
             <select name="cookbooks" id="cookbooks">
-              <option value="" selected="true" disabled="true">
-                - Select a Cookbook -
+              <option value="My cookbook" selected="true" disabled="true">
+                My cookbook
               </option>
               <option value="cookbook1">Cookbook 1</option>
             </select>

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -650,6 +650,14 @@ async function populateCookbooksPage() {
   for (const cookbook of cookbooks) {
     let card = document.createElement("cookbook-card");
     card.cookbook = cookbook;
+
+    let shadow = card.shadowRoot;
+    let title = shadow.querySelector(".title").innerHTML;
+    if (title === "My cookbook") {
+      let button = shadow.getElementById("remove");
+      button.remove();
+    }
+
     bindCookbookCardButtons(card);
 
     cardContainer.appendChild(card);
@@ -677,15 +685,14 @@ function bindCookbookCardButtons(card) {
     router.navigate("edit-cookbook");
   });
 
-  removeButton.addEventListener("click", async () => {
-    // delete cookbook, then repopulate page
-    if (title !== "My cookbook") {
+  //Check if remove button is null in default cookbook case
+  if (removeButton) {
+    removeButton.addEventListener("click", async () => {
+      // delete cookbook, then repopulate page
       await indexedDb.deleteCookbook(card.cookbook.title);
       populateCookbooksPage();
-    } else {
-      alert("You can't delete your default cookbook!");
-    }
-  });
+    });
+  }
 
   openButton.addEventListener("click", async () => {
     await populateSingleCookbook(card.cookbook);

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -662,7 +662,7 @@ async function populateCookbooksPage() {
     }
 
     bindCookbookCardButtons(card);
-    
+
     if (title === DEFAULT_COOKBOOK_NAME) {
       cardContainer.prepend(card);
     } else {
@@ -817,7 +817,7 @@ function bindSelectCookbookButtons() {
     let recipePage = document.querySelector("recipe-page");
     let selectedCookbook = shadow.getElementById("cookbooks").value;
 
-    if (selectedCookbook !== "" && !recipePage.classList.contains("hidden")) {
+    if (!recipePage.classList.contains("hidden")) {
       let recipeId =
         recipePage.shadowRoot.getElementById("recipe-page-id").textContent;
       let recipeObj = await spoonacular.getRecipeInfo(recipeId);

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -1032,8 +1032,14 @@ function addRecipe() {
 }
 
 async function initializeDefaultCookbook() {
-  await indexedDb.createCookbook("My cookbook", "Your default cookbook!");
-  await populateCookbooksPage();
+  try {
+    await indexedDb.createCookbook("My cookbook", "Your default cookbook!");
+    await populateCookbooksPage().then(() => {});
+  } catch (err) {
+    console.log(
+      "Default attempted to be created again. Probably just a page reload."
+    );
+  }
 }
 
 /**

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -679,8 +679,12 @@ function bindCookbookCardButtons(card) {
 
   removeButton.addEventListener("click", async () => {
     // delete cookbook, then repopulate page
-    await indexedDb.deleteCookbook(card.cookbook.title);
-    populateCookbooksPage();
+    if (title !== "My cookbook") {
+      await indexedDb.deleteCookbook(card.cookbook.title);
+      populateCookbooksPage();
+    } else {
+      alert("You can't delete your default cookbook!");
+    }
   });
 
   openButton.addEventListener("click", async () => {
@@ -804,6 +808,12 @@ function bindSelectCookbookButtons() {
         recipePage.shadowRoot.getElementById("recipe-page-id").textContent;
       let recipeObj = await spoonacular.getRecipeInfo(recipeId);
       await indexedDb.addRecipe(selectedCookbook, recipeObj);
+
+      //If the selected cookbook wasn't the default,
+      if (selectedCookbook !== "My cookbook") {
+        //Add the recipe to the default cookbook also
+        await indexedDb.addRecipe("My cookbook", recipeObj);
+      }
       notificationSelectCookbook.classList.toggle("hidden");
     }
   });
@@ -1014,6 +1024,11 @@ function addRecipe() {
   });
 }
 
+async function initializeDefaultCookbook() {
+  await indexedDb.createCookbook("My cookbook", "Your default cookbook!");
+  await populateCookbooksPage();
+}
+
 /**
  * Runs initial setup functions when the page first loads
  * @function init
@@ -1060,6 +1075,8 @@ async function init() {
   bindSelectCookbookButtons();
 
   populateCookbooksPage();
+
+  initializeDefaultCookbook();
 }
 
 window.addEventListener("DOMContentLoaded", init);

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -785,7 +785,7 @@ async function populateSelectCookbookOptions() {
 
   let cookbooks = await indexedDb.getAllCookbooks();
 
-  for (let i = 0; i < cookbooks.length; ++i) {
+  for (let i = 1; i < cookbooks.length; ++i) {
     let option = document.createElement("option");
     option.value = cookbooks[i].title;
     option.textContent = cookbooks[i].title;

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -649,8 +649,6 @@ async function populateCookbooksPage() {
   let cookbooks = await indexedDb.getAllCookbooks();
 
   // add each cookbook to the page as a new card
-  let defaultCookbook = null;
-
   for (let i = 0; i < cookbooks.length; i++) {
     let card = document.createElement("cookbook-card");
     card.cookbook = cookbooks[i];

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -1032,6 +1032,8 @@ function addRecipe() {
 }
 
 async function initializeDefaultCookbook() {
+  "use strict";
+
   try {
     await indexedDb.createCookbook("My cookbook", "Your default cookbook!");
     await populateCookbooksPage().then(() => {});

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -649,21 +649,27 @@ async function populateCookbooksPage() {
   let cookbooks = await indexedDb.getAllCookbooks();
 
   // add each cookbook to the page as a new card
-  for (const cookbook of cookbooks) {
+  let defaultCookbook = null;
+
+  for (let i = 0; i < cookbooks.length; i++) {
     let card = document.createElement("cookbook-card");
-    card.cookbook = cookbook;
+    card.cookbook = cookbooks[i];
 
     let shadow = card.shadowRoot;
     let title = shadow.querySelector(".title").innerHTML;
+
     if (title === DEFAULT_COOKBOOK_NAME) {
       let button = shadow.getElementById("remove");
       button.remove();
+      defaultCookbook = card;
+      continue;
     }
 
     bindCookbookCardButtons(card);
 
     cardContainer.appendChild(card);
   }
+  cardContainer.prepend(defaultCookbook);
 }
 
 /**
@@ -785,7 +791,7 @@ async function populateSelectCookbookOptions() {
 
   let cookbooks = await indexedDb.getAllCookbooks();
 
-  for (let i = 1; i < cookbooks.length; ++i) {
+  for (let i = 0; i < cookbooks.length; ++i) {
     let option = document.createElement("option");
     option.value = cookbooks[i].title;
     option.textContent = cookbooks[i].title;

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -661,15 +661,16 @@ async function populateCookbooksPage() {
     if (title === DEFAULT_COOKBOOK_NAME) {
       let button = shadow.getElementById("remove");
       button.remove();
-      defaultCookbook = card;
-      continue;
     }
 
     bindCookbookCardButtons(card);
-
-    cardContainer.appendChild(card);
+    
+    if (title === DEFAULT_COOKBOOK_NAME) {
+      cardContainer.prepend(card);
+    } else {
+      cardContainer.appendChild(card);
+    }
   }
-  cardContainer.prepend(defaultCookbook);
 }
 
 /**

--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -7,6 +7,8 @@ const HOME_PAGE_NUM_RESULTS = 4;
 const NO_INPUT = "";
 const DEFAULT_READY_TIME = 240;
 let COOKBOOK_TO_EDIT = null;
+const DEFAULT_COOKBOOK_NAME = "My cookbook";
+
 const router = new Router("home-page");
 const spoonacular = new SpoonacularInterface();
 const indexedDb = new IndexedDbInterface();
@@ -653,7 +655,7 @@ async function populateCookbooksPage() {
 
     let shadow = card.shadowRoot;
     let title = shadow.querySelector(".title").innerHTML;
-    if (title === "My cookbook") {
+    if (title === DEFAULT_COOKBOOK_NAME) {
       let button = shadow.getElementById("remove");
       button.remove();
     }
@@ -817,9 +819,9 @@ function bindSelectCookbookButtons() {
       await indexedDb.addRecipe(selectedCookbook, recipeObj);
 
       //If the selected cookbook wasn't the default,
-      if (selectedCookbook !== "My cookbook") {
+      if (selectedCookbook !== DEFAULT_COOKBOOK_NAME) {
         //Add the recipe to the default cookbook also
-        await indexedDb.addRecipe("My cookbook", recipeObj);
+        await indexedDb.addRecipe(DEFAULT_COOKBOOK_NAME, recipeObj);
       }
       notificationSelectCookbook.classList.toggle("hidden");
     }
@@ -1035,7 +1037,10 @@ async function initializeDefaultCookbook() {
   "use strict";
 
   try {
-    await indexedDb.createCookbook("My cookbook", "Your default cookbook!");
+    await indexedDb.createCookbook(
+      DEFAULT_COOKBOOK_NAME,
+      "Your default cookbook!"
+    );
     await populateCookbooksPage().then(() => {});
   } catch (err) {
     console.log(

--- a/source/scripts/spoonacular-interface.js
+++ b/source/scripts/spoonacular-interface.js
@@ -50,7 +50,7 @@ const MOCK_RECIPE_INFO = {
 };
 
 // Change this variable to true to make real API calls to Spoonacular
-let SPOONACULAR_ENABLED = true;
+let SPOONACULAR_ENABLED = false;
 
 /**
  * @classdesc An interface for fetching recipes and recipe information using

--- a/source/scripts/spoonacular-interface.js
+++ b/source/scripts/spoonacular-interface.js
@@ -50,7 +50,7 @@ const MOCK_RECIPE_INFO = {
 };
 
 // Change this variable to true to make real API calls to Spoonacular
-let SPOONACULAR_ENABLED = false;
+let SPOONACULAR_ENABLED = true;
 
 /**
  * @classdesc An interface for fetching recipes and recipe information using


### PR DESCRIPTION
Resolves #173 

**Description**

Creates a default cookbook that cannot be deleted. This is resolved by removing the trashcan button from the card if it matches the title "My cookbook". The default cookbook is created through an initialization function that is called in the init function in app.js. Note that because the init function runs upon reload, the console may get spammed with error messages about duplicate creations of a cookbook. Also, any recipe that gets added to another cookbook will also get added to this cookbook. I added an if statement in one of the functions that checks for the title of the cookbook when adding so that the function doesn't add a recipe to the cookbook twice when you pick the default cookbook to add your recipe to.

![defaultcookbook](https://user-images.githubusercontent.com/68366290/143096681-897ec6a7-f218-45ef-ad30-08ac61c5f503.PNG)

