### PR TITLE
scroll to top after navigating, one line fix

### DIFF
--- a/source/scripts/router.js
+++ b/source/scripts/router.js
@@ -37,6 +37,8 @@ export class Router {
       this.currentPage = page;
       //Toggle hidden on page
       pageElement.classList.toggle("hidden");
+      //Scroll to top of page
+      document.querySelector("html").scrollTop = 0;
     }
   }
 }


### PR DESCRIPTION
Resolves #192 

**Description**

Added a line to router that will scroll to the top of a page after you navigate.
