### PR TITLE
Only generate docs after checking out documentation branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,8 +3,6 @@ name: documentation
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,16 +22,17 @@ jobs:
 
       - name: Install JSDoc
         run: npm install --save-dev jsdoc
-      - name: Generate documentation with JSDoc
-        run: npm run create-docs
-
-      - name: Commit new documentation to main
+      - name: Get latest changes from main and perform setup
         run: |
           git config user.name "Impasta Rosta Documentation"
           git config user.email "impastarosta@gmail.com"
           git pull origin main
           git remote update origin --prune
+
+      - name: Generate documentation with JSDoc
+        run: |
           git checkout documentation
+          npm run create-docs
           git add docs/
           git commit -m "generated documentation"
           git push origin HEAD:documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout GitHub repository
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           ref: main
 
       - name: Use Node.js

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,8 @@ name: documentation
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 
@@ -32,6 +34,7 @@ jobs:
       - name: Generate documentation with JSDoc
         run: |
           git checkout documentation
+          git merge main
           npm run create-docs
           git add docs/
           git commit -m "generated documentation"


### PR DESCRIPTION
Resolves #185 

**Description**

Fix for JSDoc workflow to only generate docs after checking out `documentation` branch
