### PR TITLE
Remove hyperlinks from recipe descriptions

### DIFF
--- a/source/components/recipe-page.js
+++ b/source/components/recipe-page.js
@@ -1,3 +1,5 @@
+const ANCHOR_REGEX = /(<a(.+?)?>|<\/a>)/g;
+
 /**
  * @classdesc This class represents the recipe page, which is used for
  *            displaying detailed info about an open recipe
@@ -114,7 +116,7 @@ export class RecipePage extends HTMLElement {
 
     shadow.getElementById("recipe-image").src = recipeObj.image;
     shadow.getElementById("recipe-description").innerHTML =
-      recipeObj.description;
+      recipeObj.description.replace(ANCHOR_REGEX, ""); // remove links
 
     let ingredientAmounts = [];
     let ingredientsLeft = shadow.getElementById(

--- a/source/components/recipe-page.js
+++ b/source/components/recipe-page.js
@@ -115,8 +115,10 @@ export class RecipePage extends HTMLElement {
     }
 
     shadow.getElementById("recipe-image").src = recipeObj.image;
-    shadow.getElementById("recipe-description").innerHTML =
-      recipeObj.description.replace(ANCHOR_REGEX, ""); // remove links
+
+    let cleanedDesc = recipeObj.description.replace(ANCHOR_REGEX, ""); // remove links
+    shadow.getElementById("recipe-description").innerHTML = cleanedDesc;
+    this.recipe.description = cleanedDesc;
 
     let ingredientAmounts = [];
     let ingredientsLeft = shadow.getElementById(


### PR DESCRIPTION
Resolves #240 

**Description**

Deletes all anchor tags present in the recipe object's description, while leaving the rest of the text intact. This may make some descriptions a bit confusing or unnecessarily wordy, but fancier string manipulation is probably not worth pursuing.